### PR TITLE
Fix: Fix Github repo links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -214,7 +214,7 @@ const config = {
           //   position: "left",
           // },
           {
-            href: "https://github.com/natalieagus/2023-50033",
+            href: "https://github.com/natalieagus/50033",
             label: "GitHub",
             position: "right",
           },
@@ -245,7 +245,7 @@ const config = {
             items: [
               {
                 label: "GitHub",
-                href: "https://github.com/natalieagus/2023-50033",
+                href: "https://github.com/natalieagus/50033",
               },
             ],
           },


### PR DESCRIPTION
Modified the Github links in docusaurus.config.js, since they originally linked to natalieagus/2023-50033 instead of natalieagus/50033.