### PR TITLE
Fix: various typos, missing deathImpulse declaration

### DIFF
--- a/docs/02-babies/animation.md
+++ b/docs/02-babies/animation.md
@@ -226,6 +226,7 @@ Then head to `PlayerMovement.cs` and edit the `OnTriggerEnter2D` and `ResetGame`
 
 //highlight-start
     public AudioClip marioDeath;
+    public float deathImpulse = 15;
 
     // state
     [System.NonSerialized]

--- a/docs/02-babies/physics.md
+++ b/docs/02-babies/physics.md
@@ -94,8 +94,8 @@ For **layer-based rendering**, we can decide what to be rendered (only a selecti
 **Create** two other layers via any GameObject Inspector: `Enemies` and `Obstacles`.
 
 1. Set `Pipes` GameObject Layer to `Obstacles`.
-2. Set `Obstacles` GameoBject Layer to `Obstacles` too.
-3. Set all `Enemies` GameObject Layer to `Enemies`. `
+2. Set `Obstacles` GameObject Layer to `Obstacles` too.
+3. Set all `Enemies` GameObject Layer to `Enemies`. 
 
 > Apply it to all their **children**.
 

--- a/docs/03-toddlers/management.md
+++ b/docs/03-toddlers/management.md
@@ -135,7 +135,7 @@ There are [**four** different workflows](https://docs.unity3d.com/Packages/com.u
 
 This method allows us to define actions, properties, and interactions via the GUI as shown above, _and then_ instantiate and register callbacks via the script attached to the GameObject we want to control. The documentation related to this section is [here](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.6/manual/Workflow-ActionsAsset.html).
 
-Since we have generated the C# script: `MarioActions.cs` from the Action Asset, we can instantiate it directly in the code under `Start`, then `enable` it. Then we can address the actions directly via `marioActions` asa follows and register the callbacks we want. The callback must have the signature: return value `void` and receive one argument of type: `InputAction.CallbackContext`.
+Since we have generated the C# script: `MarioActions.cs` from the Action Asset, we can instantiate it directly in the code under `Start`, then `enable` it. Then we can address the actions directly via `marioActions` as follows and register the callbacks we want. The callback must have the signature: return value `void` and receive one argument of type: `InputAction.CallbackContext`.
 
 ```cs
     public MarioActions marioActions;


### PR DESCRIPTION
`docs/02-babies/animation.md`: Added a `deathImpulse` declaration in the sample code for the death animation section, as it was missing.

`docs/02-babies/physics.md`: Fixed a couple of typos in the layer-based collision section (gameoBject and an extra backtick).

`docs/03-toddlers/management.md`: Fixed a typo in the registering callbacks section (`marioBody` **asa** follows).