### PR TITLE
fix: add --legacy-peer-deps to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can contribute by forking this repository and creating pull requests 😊
 
 ## Getting started
 
-1. Clone this project, then `npm install`
+1. Clone this project, then `npm install --legacy-peer-deps`
 2. Afterwards, type `npm start`
 3. You can publish this site to github automatically by pushing this to your `master` branch. See `.github/workflows/deploy.yml` action script
 4. You need to give **read and write** Action permission in your workflow


### PR DESCRIPTION
Added --legacy-peer-deps to avoid dependency errors as below when doing "npm install":
Also follows GitHub Actions workflow file of using this option.

> npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @easyops-cn/docusaurus-search-local@0.33.6
npm error Found: @docusaurus/theme-common@3.7.0
npm error node_modules/@docusaurus/theme-common
npm error   @docusaurus/theme-common@"^3.7.0" from the root project
npm error   @docusaurus/theme-common@"3.7.0" from @docusaurus/plugin-content-blog@3.7.0
npm error   node_modules/@docusaurus/plugin-content-blog
npm error     @docusaurus/plugin-content-blog@"3.7.0" from @docusaurus/preset-classic@3.7.0
npm error     node_modules/@docusaurus/preset-classic
npm error       @docusaurus/preset-classic@"^3.7.0" from the root project
npm error     @docusaurus/plugin-content-blog@"3.7.0" from @docusaurus/theme-classic@3.7.0
npm error     node_modules/@docusaurus/theme-classic
npm error       @docusaurus/theme-classic@"3.7.0" from @docusaurus/preset-classic@3.7.0
npm error       node_modules/@docusaurus/preset-classic
npm error         @docusaurus/preset-classic@"^3.7.0" from the root project
npm error   5 more (@docusaurus/plugin-content-docs, ...)
npm error
npm error Could not resolve dependency:
npm error peer @docusaurus/theme-common@"^2.0.0-rc.1" from @easyops-cn/docusaurus-search-local@0.33.6
npm error node_modules/@easyops-cn/docusaurus-search-local
npm error   @easyops-cn/docusaurus-search-local@"^0.33.6" from the root project
npm error
npm error Conflicting peer dependency: @docusaurus/theme-common@2.4.3
npm error node_modules/@docusaurus/theme-common
npm error   peer @docusaurus/theme-common@"^2.0.0-rc.1" from @easyops-cn/docusaurus-search-local@0.33.6
npm error   node_modules/@easyops-cn/docusaurus-search-local
npm error     @easyops-cn/docusaurus-search-local@"^0.33.6" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.