### PR TITLE
Update static.md

### DIFF
--- a/docs/04-children/static.md
+++ b/docs/04-children/static.md
@@ -484,7 +484,7 @@ TL;DR: If you're expecting **standard** polymorphism behavior, use `virtual` met
 
 <DeepDive>
 
-The difference between the two is very apparent in this example, especially when we declare object type `BaseClass` using `DerivedClass` constructor. The output of line `40` will be **different** to the output of line `39`.
+The difference between the two is very apparent in this example, especially when we declare object type `BaseClass` using `DerivedClass` constructor. The output of line `42` will be **different** to the output of line `38`.
 
 ```cs showLineNumbers
 using UnityEngine;


### PR DESCRIPTION
Fixed Logic error in deep dive on  override vs new keyword .

Currently the website says this  'The output of line 40 will be different to the output of line 39.'
However , one of these lines ( line 39) is a comment , which does not make sense .

![Screenshot 2025-02-21 at 6 31 26 PM](https://github.com/user-attachments/assets/199483c9-692e-45ae-a3ad-65a74f561e14)

From my understanding of override vs new keyword , there could be two things that the deep dive could want to convey . 

Option1 . Line 38 and Line 42 ( dc.Method2() & bc.Method2()) They have different looking outputs as apposed to dc.Method1() and bc.Method1() which have the same outputs. The lines comment could referring to that discrepancy.

Option2. Linke 41 & 42 . (bc.Method1() and bc.Method2()) 
The line could be drawing attention to the fact that bc.Method2() has only one line of output and b2.Method1() has two lines . The comments also reference this . This is far more likely the correct set of lines as they have the same x, x+1  line reference. 