### PR TITLE
fix: use waitwhile enemies > 0 instead of >= 0

### DIFF
--- a/docs/04-children/coroutines.md
+++ b/docs/04-children/coroutines.md
@@ -216,7 +216,7 @@ public class WaitWhileExample : MonoBehaviour
     IEnumerator Rescue(string name)
     {
         Debug.Log($"Waiting for Mario to rescue {name}...");
-        yield return new WaitWhile(() => enemies >= 0);
+        yield return new WaitWhile(() => enemies > 0);
         Debug.Log($"Finally, all enemies are eliminated and {name} have been rescued!");
     }
 


### PR DESCRIPTION
In the typical use case where the minimum number of enemies is 0, the coroutine will not yield.