### PR TITLE
Pull Request: Fix Missing Titles in Sidebar Rendering Issue

### DIFF
--- a/about/lab-competition/2025.md
+++ b/about/lab-competition/2025.md
@@ -88,7 +88,7 @@ Dian, Jamie
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab2-dian-jamie.mp4"} widthPercentage="100%"/>
 
-#### Isekai Mario
+### Isekai Mario
 
 Mario + Flappy Bird mashup to fly? Why not!
 
@@ -100,7 +100,7 @@ Xingrui, Xavier
 
 ## 🥇 Lab 3
 
-#### Isekai Mario v2.0
+### Isekai Mario v2.0
 
 Seriously, excellent effort!
 
@@ -110,7 +110,7 @@ Xingrui, Xavier
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab3-xingrui-xavier-isekai-mario.mp4"} widthPercentage="100%"/>
 
-#### Stress Relief
+### Stress Relief
 
 This is really dark.
 
@@ -122,7 +122,7 @@ Lucas
 
 ## 🥇 Lab 4
 
-#### Potion Madness
+### Potion Madness
 
 Repel the 💩!
 
@@ -132,7 +132,7 @@ Janessa, Ryan
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab4-janessa-potion-madness.mp4"} widthPercentage="100%"/>
 
-#### AstroCats v4
+### AstroCats v4
 
 The cute cats made a comeback.
 
@@ -142,7 +142,7 @@ Simriti, Kelly
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab4-kelly-sim-astro-cats.mp4"} widthPercentage="100%"/>
 
-#### Battleshipz
+### Battleshipz
 
 Excellent artwork.
 
@@ -152,7 +152,7 @@ Lucas
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab4-lucas-battleshipz.mp4"} widthPercentage="100%"/>
 
-#### IsekaiMario v3.0
+### IsekaiMario v3.0
 
 When you are skilled in both gaming and game design.
 
@@ -164,7 +164,7 @@ Xingrui, Xavier
 
 ## 🥇 Lab 5
 
-#### Cooked
+### Cooked
 
 It's like Overcooked, but the simpler version, hence: cooked.
 
@@ -174,7 +174,7 @@ Chee Kiat, Guru
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab5-cheekiat-delivery.mp4"} widthPercentage="100%"/>
 
-#### Mocchi Adventures
+### Mocchi Adventures
 
 :::author
 Jaikirat, Isaac
@@ -182,7 +182,7 @@ Jaikirat, Isaac
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab5-jaikirat-isaac-mocchi.mp4"} widthPercentage="100%"/>
 
-#### Bullet Dance
+### Bullet Dance
 
 We have a repeated winner here.
 
@@ -192,7 +192,7 @@ Lucas
 
 <VideoItem path={"https://50033.s3.ap-southeast-1.amazonaws.com/lab-winners/2024/lab5-lucas-bullet-dance.mp4"} widthPercentage="100%"/>
 
-#### Sephere v0.5
+### Sephere v0.5
 
 You're supposed to save time when your final project can be used as lab submission, but not when you write the game engine on your own in Rust.
 


### PR DESCRIPTION
This PR fixes an issue where some markdown (.md) files were not rendering their titles in the sidebar, even though they existed in the docs/ directory. The problem was traced to incorrect markdown heading levels (#### instead of ###), preventing Docusaurus from recognizing them properly.

I checked sidebars.js and confirmed it used { type: "autogenerated", dirName: "." }, meaning Docusaurus should automatically pull headings.

Compared working and non-working .md titles.
Discovered that missing entries used #### instead of ###. Other labs consistently used ###, which rendered correctly.

Updated #### to ### for subheadings under Lab 5.

Attached Before & After ( After is shown ) 

![Screenshot 2025-03-10 at 3 56 28 PM](https://github.com/user-attachments/assets/c6fc408d-7cea-4b3f-a746-02ae4eeb48ce)
![Screenshot 2025-03-10 at 3 59 44 PM](https://github.com/user-attachments/assets/fcfd893a-14b6-4b13-a8c4-16df78e19a4d)